### PR TITLE
Fixes BannerDoble responsive sizes

### DIFF
--- a/src/components/BannerDoble/BannerDoble.scss
+++ b/src/components/BannerDoble/BannerDoble.scss
@@ -48,6 +48,10 @@
         max-width: 40px;
       }
     }
+    h2,
+    h3 {
+      font-size: 1.75rem;
+    }
   }
 }
 
@@ -97,6 +101,12 @@
     .Text {
       .TextContainer {
         padding-bottom: 0;
+        h2 {
+          font-size: 2.25rem;
+        }
+        h3 {
+          font-size: 2rem;
+        }
       }
     }
   }
@@ -104,18 +114,17 @@
 
 @media (min-width: $breakpoint-lg) {
   .BannerDoble {
-
     grid-template-columns:
       1fr var(--left-column-width, 320px) var(--right-column-width, 640px)
       1fr;
-      .Text .TextContainer .Subtitle {
-        img {
-          max-width: 50px;
-        }
+    .Text .TextContainer .Subtitle {
+      img {
+        max-width: 50px;
       }
-      .ImageContainer {
-        padding: 5rem 2.5rem;
-      }
+    }
+    .ImageContainer {
+      padding: 5rem 2.5rem;
+    }
   }
 }
 
@@ -124,16 +133,15 @@
     grid-template-columns:
       1fr var(--left-column-width, 370px) var(--right-column-width, 740px)
       1fr;
-      .Text {
-        justify-content: start;
-        padding-left: 5rem;
-      }
+    .Text {
+      justify-content: start;
+      padding-left: 5rem;
+    }
   }
 }
 
 @media (min-width: $breakpoint-xxl) {
   .BannerDoble {
-
     grid-template-columns:
       1fr var(--left-column-width, 420px) var(--right-column-width, 840px)
       1fr;
@@ -142,7 +150,6 @@
 
 @media (min-width: $breakpoint-xxxl) {
   .BannerDoble {
-
     grid-template-columns:
       1fr var(--left-column-width, 470px) var(--right-column-width, 940px)
       1fr;
@@ -151,7 +158,6 @@
 
 @media (min-width: $breakpoint-xxxxl) {
   .BannerDoble {
-
     grid-template-columns:
       1fr var(--left-column-width, 520px) var(--right-column-width, 1040px)
       1fr;


### PR DESCRIPTION
Reduce los tamaños de los headings en la version mobile del BannerDoble, para evitar que el texto crezca demasiado.